### PR TITLE
Crownjbl use actual points

### DIFF
--- a/edef/sc_buffer.py
+++ b/edef/sc_buffer.py
@@ -15,7 +15,6 @@ NUM_MASK_BITS = 9
 Instantiate a BSABuffer object to reserve one of the buffers.  Configure it,
 then start data aquisition with the 'start' method."""
 class BSABuffer(object):
-    print('dev bsabuffer!')
     prefix = "BSA:SYS0:1"
     def __init__(self, name, user=None, number=None, avg=1, measurements=1000, destination_mode=None, destination_masks=None, avg_callback=None, measurements_callback=None, ctrl_callback=None):
         if number is None:


### PR DESCRIPTION
Modified get_buffer method in sc_buffer.py to use actual number of acquired points when slicing data buffers. It uses the pre-existing self.num_acquired() method to get the number of acquired points. Also added check that BSA Ready flag is ready before grabbing data. This check is skipped if the number of actual acquired points is 0, because in that case empty lists will be returned and it is pointless (and often slow) to wait for the ready flag to change.

I added a simple while loop to watch the ready flag, without a timeout value. This isn't ideal, but it's tricky because the time it takes for the BSA Ready status to change to 'Ready' is highly variable and can take many tens of seconds in certain situations (even if 0 actual points were acquired!). I expect that to improve in the future as the BSA system gets better, but it's difficult to think of a proper timeout to assign for such a waiting loop. And we've been told you should not retrieve data until the status reads ready, so we need to wait for it to turn ready and shouldn't return data otherwise.